### PR TITLE
Add dependencies required to build new version of xmrig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ RUN   apk --no-cache upgrade && \
         git \
         cmake \
         libuv-dev \
-        build-base && \
+        build-base \
+        openssl-dev \
+        libmicrohttpd-dev && \
       git clone https://github.com/xmrig/xmrig && \
       cd xmrig && \
       mkdir build && \


### PR DESCRIPTION
I've added openssl and microhttpd dependencies, which are required to build the newest version of xmrig using the default build settings. These changes have been confirmed to work with v2.14.1.

Running this docker image without an updated xmrig will likely submit bad shares to a mining pool and may penalize your miner. It is strongly recommended to update to the newest version of xmrig.